### PR TITLE
Update README.md typos and metadata example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,21 @@ Use the `disabled` property to use a control for display purposes only
 <input name="star3" type="radio" class="star" disabled="disabled"/>
 <input name="star3" type="radio" class="star" disabled="disabled"/>
 ```
-####Split-stars with the matadata plugin
+####Split-stars with the metadata plugin
 Use the `metadata` plugin to pass advanced settings to the plugin via the class property.
+The example below creates 4 total stars with a selected value of 1.25 (1 and a quarter star).
+The total number of stars is the number of radios divided by the split, in this case 16/4 = 4.
+The number of stars selected is the ordinal value of the radio selected divided by the split, in this case 5/4 = 1.25
 ```html
 <input name="adv1" type="radio" class="star {split:4}"/>
 <input name="adv1" type="radio" class="star {split:4}"/>
 <input name="adv1" type="radio" class="star {split:4}"/>
 <input name="adv1" type="radio" class="star {split:4}"/>
 <input name="adv1" type="radio" class="star {split:4}" checked="checked"/>
+<input name="adv1" type="radio" class="star {split:4}"/>
+<input name="adv1" type="radio" class="star {split:4}"/>
+<input name="adv1" type="radio" class="star {split:4}"/>
+<input name="adv1" type="radio" class="star {split:4}"/>
 <input name="adv1" type="radio" class="star {split:4}"/>
 <input name="adv1" type="radio" class="star {split:4}"/>
 <input name="adv1" type="radio" class="star {split:4}"/>


### PR DESCRIPTION
Fixed a small typo in the README.md file and went a little more indepth on using split stars
