### PR TITLE
Adding fallback value to aria-label

### DIFF
--- a/jquery.rating.js
+++ b/jquery.rating.js
@@ -117,7 +117,7 @@
 			}; // first element of group
 			
 			// insert rating star (thanks Jan Fanslau rev125 for blind support https://code.google.com/p/jquery-star-rating-plugin/issues/detail?id=125)
-			var star = $('<div role="text" aria-label="'+ this.title +'" class="star-rating rater-'+ control.serial +'"><a title="' + (this.title || this.value) + '">' + this.value + '</a></div>');
+			var star = $('<div role="text" aria-label="'+ (this.title || this.value) +'" class="star-rating rater-'+ control.serial +'"><a title="' + (this.title || this.value) + '">' + this.value + '</a></div>');
 			rater.append(star);
 			
 			// inherit attributes from input element


### PR DESCRIPTION
In some situations, this.title is unavailable, however a fallback to this.value was not specified for the aria-label. This would occasionally result in inconsistencies between the anchor tag's title attribute and the parent div's aria label.
